### PR TITLE
Fix duplicate about IDs

### DIFF
--- a/WegSleepDirect_Website/index.html
+++ b/WegSleepDirect_Website/index.html
@@ -133,7 +133,7 @@
             </div>
         </section>
 
-        <section id="about" class="about">
+        <section id="about-service" class="about">
             <h2>Snelle en Betrouwbare Sleepservice bij Pech Onderweg</h2>
             <p>
                 Pech onderweg? Of het nu gaat om een lekke band, een lege accu of een oververhitte motor, wij staan direct voor u klaar. 
@@ -157,7 +157,7 @@
             </ul>
         </section>
 
-        <section id="about" class="about">
+        <section id="about-us" class="about">
             <h2>Waarom Kiezen Voor Ons?</h2>
             <p>Heeft u pech onderweg? Eén telefoontje en wij staan direct voor u klaar! Wij proberen het probleem ter plaatse op te lossen. Lukt dat niet? Dan vervoeren wij uw voertuig veilig naar een locatie naar keuze.</p>
         </section>
@@ -167,7 +167,7 @@
             <p>Wij bieden 24/7 professionele pechhulp en transportdiensten in de hele Benelux en Duitsland. Waar u ook bent, wij helpen u snel weer op weg!</p>
         </section>
         
-        <section id="about" class="about">
+        <section id="about-cost" class="about">
             <h2>Geen Verborgen Kosten</h2>
             <p>Transparantie staat bij ons voorop. U betaalt alleen voor de service die u nodig heeft, zonder abonnementen of onverwachte kosten. Zo weet u altijd waar u aan toe bent.</p>
         </section>


### PR DESCRIPTION
## Summary
- fix duplicate `about` section IDs on the index page

## Testing
- `html5validator` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68669d6881848333b1129752e0669ad5